### PR TITLE
Bugfix: 쿼리문에서 직접적인 updated_at 데이터 수정 삭제

### DIFF
--- a/crawling/koreatech_dining.py
+++ b/crawling/koreatech_dining.py
@@ -182,12 +182,12 @@ def updateDB(menus):
             sql = """
             INSERT INTO koin.dining_menus(date, type, place, price_card, price_cash, kcal, menu)
             VALUES ('%s', '%s', '%s', %s, %s, %s, '%s')
-            ON DUPLICATE KEY UPDATE price_card = %s, price_cash = %s, kcal = %s, menu = '%s', updated_at = '%s'
+            ON DUPLICATE KEY UPDATE price_card = %s, price_cash = %s, kcal = %s, menu = '%s'
             """
 
             values = (
                 menu.date, menu.dining_time, menu.place, menu.price_card, menu.price_cash, menu.kcal, menu.menu,
-                menu.price_card, menu.price_cash, menu.kcal, menu.menu, datetime.datetime.now()
+                menu.price_card, menu.price_cash, menu.kcal, menu.menu
             )
 
             print(sql % values)

--- a/crawling/koreatech_notice.py
+++ b/crawling/koreatech_notice.py
@@ -143,12 +143,12 @@ def updateDB(nas):
         try:
             notice_sql = "INSERT INTO koin.notice_articles(board_id, title, content, author, hit, is_deleted, article_num, permalink, has_notice, registered_at) \
                 VALUES (%d, '%s', '%s', '%s', %d, %d, %d, '%s', %d, '%s') \
-                    ON DUPLICATE KEY UPDATE title = '%s', content = '%s', author = '%s', updated_at = '%s'"
+                    ON DUPLICATE KEY UPDATE title = '%s', content = '%s', author = '%s'"
 
             notice_query = notice_sql % (
                 na.board_id, na.title, na.content, na.author, na.hit, na.is_deleted, int(na.article_num), na.permalink,
                 na.has_notice, na.registered_at,
-                na.title, na.content, na.author, datetime.datetime.now()
+                na.title, na.content, na.author
             )
 
             cur.execute(notice_query)
@@ -160,11 +160,11 @@ def updateDB(nas):
 
             article_sql = "INSERT INTO koin.articles(board_id, title, nickname, content, user_id, ip, meta, is_notice, created_at, notice_article_id) \
                 VALUES (%d, '%s', '%s', '%s', %d, '%s', '%s', %d, '%s', %d) \
-                ON DUPLICATE KEY UPDATE title = '%s', content = '%s', nickname = '%s', updated_at = '%s'"
+                ON DUPLICATE KEY UPDATE title = '%s', content = '%s', nickname = '%s'"
 
             article_query = article_sql % (
                 na.board_id, na.title, na.author, na.content, 0, "127.0.0.1", meta, 1, na.registered_at, newNoticeId,
-                na.title, na.content, na.author, datetime.datetime.now()
+                na.title, na.content, na.author
             )
 
             cur.execute(article_query)


### PR DESCRIPTION
# Bugfix: 쿼리문에서 직접적인 updated_at 데이터 수정 삭제

**AS-IS**
- updated_at을 매번 기입함.

**TO-BE**
- updated_at을 매번 기입하지 않고, DB 내 기능에서 처리하도록 함.


**기타 사항**
- 기능, 데이터 변경사항은 없음.
- UTC-KTC 차이를 고려하지 못해 추가했었던 (무의미한) 쿼리 문을 제거함.
- 시간-현재시간과 일치하는지, 일치하지 않다면 활용가능한 지 유의해야 함.
