### PR TITLE
fix: 엑셀 52번째 열(AZ)부터 인식 못하는 오류 수정

### DIFF
--- a/crawling/koreatech_lecture.py
+++ b/crawling/koreatech_lecture.py
@@ -91,7 +91,10 @@ class WorkSheetMapper:
         if i <= 26:
             return chr(i + 64)
         else:
-            return chr(i // 26 + 64) + chr(i % 26 + 64)
+            first_char = ((i - 1) // 26)
+            second_char = ((i - 1) % 26) + 1
+        return chr(first_char + 64) + chr(second_char + 64)
+
 
     def mapping_for(self, col, row, work_sheet_helper):
         for column_name in ColumnNames:


### PR DESCRIPTION
Closes #66 

기존의 코드
```java
def get_column(self, i):
        if i <= 26:
            return chr(i + 64)
        else:
            return chr(i // 26 + 64) + chr(i % 26 + 64)
```
작업내용 :
이는 누락된 시간표 정보 21학년도 2학기 정보를 업데이트 하다가 발견한 오류 입니다.
21학년도 2학기 시간표 정보는 엑셀 열 BB까지 정보가 들어있습니다.

우선 이 상황을 이해하려면 ASCII코드로 chr(65)가 A, chr(90)이 Z라는 것을 인지하고 있어야 합니다.
기존의 코드는 엑셀의 51번째 열(AY)을 인식하는 것까지는 아무런 문제도 없어보입니다. 

하지만 52번째 열(AZ)부터 그 뒤로 쭉 원래의 의도와 다른 값이 들어감을 알 수 있습니다. 
그 예로 원래 ASCII 코드로 52번째 열인 AZ = chr(65) + chr(90)이 나와야 하지만 기존의 코드 대로라면 chr(66) + chr(64)로 B@가 들어가서 오류가 남을 알 수 있습니다.(엑셀에 없는 열)

이를 52번째 열부터도 맞는 값(AZ)이 들어갈 수 있게 수정해줬습니다.
