### PR TITLE
fix: 메뉴 파싱 기준 변경

### DIFF
--- a/crawling/koreatech_portal/dining.py
+++ b/crawling/koreatech_portal/dining.py
@@ -179,12 +179,13 @@ def parse_row(row):
         return None
 
     def parse_dish(dish_text):
-        # '\t', '\n', '\r' 제거 및 다중 공백 제거
-        dish_text = clean_text(dish_text)
+        # '\t', '\r' 제거 및 다중 공백 제거
+        dish_text = re.sub(r'[\t\r]', ' ', dish_text)
         # 마지막 칼로리 정보 및 가격 정보 제거
-        dish_text = re.sub(r'\d+ kcal.*', '', dish_text)
-        # 각 메뉴를 리스트로 변환
-        dishes = [dish.strip() for dish in dish_text.split(' ') if dish]
+        dish_text = re.sub(r'\d+ kcal.*', '', dish_text).strip()
+        dish_text = re.sub(r'\d+ 원.*', '', dish_text).strip()
+        # 줄바꿈 기준으로 메뉴를 구분
+        dishes = [dish.strip() for dish in dish_text.split('\n') if dish]
         return dishes
 
     def parse_price(price_text):


### PR DESCRIPTION
## 기존
1. 줄바꿈과 각종 공백 문자를 전부 공백 문자로 치환
2. 공백 문자를 기준으로 메뉴 자르기

크롤링 결과: `["☆3", "000원", "조식☆", "식빵", "딸기잼＆버터", "시리얼&우유", "삶은계란", "생야채샐러드"]`

## 변경
1. 각종 공백 문자를 전부 공백 문자로 치환
2. 줄바꿈 문자를 기준으로 메뉴 자르기

크롤링 결과: `["☆3,000원 조식☆", "식빵", "딸기잼＆버터", "시리얼&우유", "삶은계란", "생야채샐러드"]`