### PR TITLE
refactor: 아우누리 2차 인증 무시

### DIFF
--- a/crawling/koreatech_portal/config.example.py
+++ b/crawling/koreatech_portal/config.example.py
@@ -1,6 +1,7 @@
 PORTAL_CONFIG = {
     'id': '',
-    'pw': ''
+    'pw': '',
+    'ip': ''
 }
 
 GMAIL_CONFIG = {

--- a/crawling/koreatech_portal/login.py
+++ b/crawling/koreatech_portal/login.py
@@ -1,5 +1,5 @@
 import time
-from selenium import webdriver
+from seleniumwire import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -16,6 +16,13 @@ def check_for_alert(driver, timeout=5):
         print("알림창 제거")
     except:
         print("알림창 없음")
+
+
+# request 인터셉트 후 ip 숨기기
+def interceptor(request):
+    request.headers["X-Forwarded-For"] = config.PORTAL_CONFIG["ip"]
+    request.headers["X-Real-IP"] = config.PORTAL_CONFIG["ip"]
+
 
 def portal_login():
     # 설정 불러오기
@@ -39,6 +46,8 @@ def portal_login():
 
     driver = webdriver.Chrome(options=options)
     driver.execute_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
+
+    driver.request_interceptor = interceptor
 
     try:
         # 웹사이트로 이동
@@ -101,8 +110,9 @@ def portal_login():
         else:
             print('로그인 실패 - 예상치 못한 url 접근: ' + url)
             return None
-    except:
+    except Exception as e:
         print('로그인 실패 - 로직 수행 간 오류 발생')
+        print(e)
         return None
     finally:
         driver.quit()
@@ -124,3 +134,6 @@ def portal_login():
 비밀번호 변경: //*[@id="pwdUpdateFrm"]/div/div/div[3]/div/ul/li[1]/a
 다음에 변경: //*[@id="pwdUpdateFrm"]/div/div/div[3]/div/ul/li[2]/a
 """
+
+if __name__ == '__main__':
+    print(portal_login()['__KSMSID__'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ selenium
 redis
 lxml
 pytz
+selenium-wire
+blinker==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,3 @@ selenium
 redis
 lxml
 pytz
-selenium-wire
-blinker==1.7.0


### PR DESCRIPTION
[대학 웹서비스(아우누리, 웹메일) 2차인증 적용 관련 안내](https://www.koreatech.ac.kr/notice/view.es?mid=a10604010000&board_id=14&post_seq=31809&prefix_id=0) 공지를 보면 교내 ip의 경우 2차인증이 필요 없음을 알 수 있습니다.

학교의 'KOREATECH' 와이파이에 접속하여 ip를 확인해보면 
<img width="1243" alt="image" src="https://github.com/BCSDLab/KOIN_BATCH/assets/46699595/81d3653f-3914-49ef-b1ef-9213252b7b77">
'Korea University of Technology and Education' 제공으로 뜨게 됩니다.
따라서 `X-Forwarded-For`, `X-Real-IP` 헤더를 추가하여 Client IP를 `203.255.221.XXX`인것처럼 속여주면 2차 인증 없이 로그인 할 수 있게 됩니다.

-----------------

- request들을 인터셉트하여 `X-Forwarded-For`, `X-Real-IP` 헤더를 추가해주도록 수정하였습니다.
- 막힐 경우를 생각하여 기존 2차인증 코드는 삭제하지 않았습니다.

-----------------

참고자료:
- https://umbum.dev/1221/
- https://github.com/AdguardTeam/StealthMode/blob/master/Extension/lib/stealth.js#L145
- https://stackoverflow.com/a/51919307
- 친구 제보:
<img width="200" alt="image" src="https://github.com/BCSDLab/KOIN_BATCH/assets/46699595/ad0e21c8-57f2-444a-9511-e636e28aeb54">