### PR TITLE
feat: 게시글 삭제

### DIFF
--- a/crawling/koreatech_article/article.py
+++ b/crawling/koreatech_article/article.py
@@ -8,6 +8,8 @@ import requests
 from bs4 import BeautifulSoup, Comment
 import urllib3
 import pymysql
+
+from delete_article import delete_article
 from table import replace_table
 from login import login
 from login import get_jwt_token
@@ -562,6 +564,7 @@ if __name__ == "__main__":
                 new_articles.extend(filter_nas(connection, board_articles))
 
                 update_db(board_articles)
+                delete_article(connection, board.id, board_articles, get_cookies(board))
         except Exception as error:
             raise error
         finally:

--- a/crawling/koreatech_article/delete_article.py
+++ b/crawling/koreatech_article/delete_article.py
@@ -1,0 +1,80 @@
+import requests
+from bs4 import BeautifulSoup
+
+
+def make_sql(board_id, articles):
+    sql = f'''
+        SELECT na.id, nka.url
+        FROM new_articles na
+            JOIN new_koreatech_articles nka ON na.id = nka.article_id
+        WHERE na.board_id = {board_id}
+        AND na.is_delete = 0
+        '''
+
+    exists = ', '.join(str(article.id) for article in articles)
+    if exists:
+        sql += f'AND na.id NOT IN ({exists})\n'
+
+    sql += 'ORDER BY na.id ASC LIMIT 60'
+
+    return sql
+
+
+def is_deleted(board_id, response):
+    try:
+        # 취업 공지가 아닌 경우
+        if board_id != 8:
+            return '/eXPortal/ctt/css/error.css' in response.text
+
+        # 취업 공지
+        if response.url == 'https://job.koreatech.ac.kr/ErrorPages/warning.html':
+            return True
+
+        html = BeautifulSoup(response.text, 'html.parser')
+
+        # content가 비어있으면 삭제된 것이므로 이므로 True
+        return not html.select_one('#content').text.strip()
+    except Exception as e:
+        print(e)
+        return False
+
+
+def delete_article(connection, board_id, articles, cookies):
+    """
+    is_deleted = 1인 게시글에 대해서는 판별하지 않음
+    즉, 이미 지워졌다고 판별된 게시글에 대해서는 판별하지 않음
+
+    articles에 들어있는 게시글은 존재하는 게시글이므로 판별하지 않음
+
+    :param connection: mysql 커넥션
+    :param board_id: DB boards에 들어있는 게시판 아이디: `boards.id`
+    :param articles: 방금 막 크롤링한 따끈따끈한 게시글들
+    :param cookies: 로그인 쿠키
+    """
+    sql = make_sql(board_id, articles)
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+
+        deleted = []
+
+        for article_id, url in rows:
+            response = requests.get(url, cookies=cookies, timeout=5)
+            if is_deleted(board_id, response):
+                deleted.append(article_id)
+
+        try:
+            for article_id in deleted:
+                sql = f'UPDATE new_articles SET is_deleted = 1 WHERE id = {article_id}'
+                cursor.execute(sql)
+
+                sql = f'UPDATE new_koreatech_articles SET is_deleted = 1 WHERE article_id = {article_id}'
+                cursor.execute(sql)
+
+                connection.commit()
+                print("DELETE_QUERY :", article_id)
+
+        except Exception as e:
+            connection.rollback()
+            print(e)


### PR DESCRIPTION
db에 크롤링 데이터를 삽입/업데이트 이후 삭제 처리가 시작됩니다.
- db에 들어있는 id를 기준으로, 60개를 처리합니다.
- 크롤링 직후에 돌아가므로, 조회된 게시글은 삭제 판별에서 제외됩니다.
- 삭제 처리된 게시글은 판별에서 제외됩니다.

따라서 크롤링이 여러번 돌아가게 되면, 모든 게시글을 삭제 판별할 수 있습니다.