### PR TITLE
fix: 졸업학점 계산기 전공 크롤링 코드 에러 해결

### DIFF
--- a/crawling/graduation_credit_calculator/major_subject.py
+++ b/crawling/graduation_credit_calculator/major_subject.py
@@ -266,7 +266,7 @@ def get_or_create_course_type_id(course_type_name, conn):
 
 def insert_data_to_db(df, engine, year, keyword):
     try:
-        with (engine.begin() as conn):
+        with engine.begin() as conn:
             for _, row in df.iterrows():
                 if not row["교과목코드"]:
                     continue


### PR DESCRIPTION
전공 크롤링 코드에서 괄호를 제거하여 에러를 해결하였습니다.